### PR TITLE
Add example to add a recommended VS Code extensions across all repos

### DIFF
--- a/js-ts/vscode-extension-recommendation/vscode-extension-recommendation.batch.yml
+++ b/js-ts/vscode-extension-recommendation/vscode-extension-recommendation.batch.yml
@@ -23,7 +23,7 @@ steps:
         if (files.length <= 0) {
           console.log("Usage:");
           console.log(
-            "dd-to-recommendations.js app1/.vscode/extension.json app2/.vscode/extension.json"
+            "node add-to-recommendations.js app1/.vscode/extension.json app2/.vscode/extension.json"
           );
           process.exit(1);
         }

--- a/js-ts/vscode-extension-recommendation/vscode-extension-recommendation.batch.yml
+++ b/js-ts/vscode-extension-recommendation/vscode-extension-recommendation.batch.yml
@@ -1,0 +1,70 @@
+name: vscode-extension-recommendation-demo
+description: Add a VS Code extension to the recommended extensions list
+
+# Repositories containing this package
+on:
+  - repositoriesMatchingQuery: path:.vscode\/extensions.json$
+
+steps:
+  - run: |
+      npm root -g
+      npm install -g jsonc-parser
+      NODE_PATH=$(npm root -g) node /add-to-recommendations.js ${{repository.search_result_paths}}
+    container: node:16-alpine
+    files:
+      /add-to-recommendations.js: |
+        const fs = require("fs");
+        const path = require("path");
+        const { modify, applyEdits, parse } = require("jsonc-parser");
+
+        const EXTENSION_NAME = "sourcegraph.sourcegraph";
+
+        const files = process.argv.slice(2);
+        if (files.length <= 0) {
+          console.log("Usage:");
+          console.log(
+            "dd-to-recommendations.js app1/.vscode/extension.json app2/.vscode/extension.json"
+          );
+          process.exit(1);
+        }
+
+        for (let file of files) {
+          const filepath = path.join(process.cwd(), file);
+
+          const content = fs.readFileSync(filepath, "utf8").toString();
+          const parsedContent = parse(content);
+
+          const hasExtension =
+            Array.isArray(parsedContent.recommendations) &&
+            parsedContent.recommendations.includes(EXTENSION_NAME);
+
+          if (hasExtension) {
+            console.log(`Extension already recommended in ${file}`);
+            process.exit(0);
+          }
+
+          const edit = modify(
+            content,
+            ["recommendations", 0],
+            "sourcegraph.sourcegraph",
+            {
+              isArrayInsertion: true,
+              formattingOptions: {
+                eol: "\n",
+                insertSpaces: true,
+                tabSize: 2,
+              },
+            }
+          );
+
+          fs.writeFileSync(filepath, applyEdits(content, edit));
+          console.log(`Extension added to recommendations in ${file}`);
+        }
+
+changesetTemplate:
+  title: Add recommended VS Code extension
+  body: This extension provides a lot of value and we recommend it to all developers.
+  branch: batch-changes/add-vscode-recommended-extension
+  commit:
+    message: Add recommended VS Code extension
+  published: false

--- a/js-ts/vscode-extension-recommendation/vscode-extension-recommendation.batch.yml
+++ b/js-ts/vscode-extension-recommendation/vscode-extension-recommendation.batch.yml
@@ -67,4 +67,3 @@ changesetTemplate:
   branch: batch-changes/add-vscode-recommended-extension
   commit:
     message: Add recommended VS Code extension
-  published: false


### PR DESCRIPTION
Closes sourcegraph/sourcegraph#40199

It looks like I have worked on this at the same time as @malomarrec 😐. The main difference is that my script is written in JavaScript instead of python, lol. Thread with more context on how that happened [here](https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1660577763537989).

It took me a while to find a library that can modify the `jsonc` spec files VS Code is using (JSON + comments) which keeps the comments up and does not reformat everything. I am not sure if the python script by @malomarrec handles this case so I post mine as well.

I also put it into the js/ts examples folder since this is useful for other VS Code extensions as well, not only ours 😉 

## Test Plan

I ran it on [S2](https://sourcegraph.sourcegraph.com/users/philipp-spiess/batch-changes/asdf/executions/QmF0Y2hTcGVjOiIyZzZNQXVKTXNHMSI=/execution/workspaces/QmF0Y2hTcGVjV29ya3NwYWNlOjEwMTk=?visible=19). The diffs it created seem reasonable. I also found that `sourcegraph/sourcegraph` and `sourcegraph/devx-scratch` already have the extension added to the recommendation list.

![Screenshot 2022-08-16 at 15 40 42](https://user-images.githubusercontent.com/458591/184895513-5e39c89a-e13a-4d15-b75e-5af0842cd620.png)

